### PR TITLE
PC Boxes — agrupar favoritos por tipo

### DIFF
--- a/pokedex/app/boxes/index.tsx
+++ b/pokedex/app/boxes/index.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+} from "react-native";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "expo-router";
+import { PokemonRepository } from "../../src/data/repositories/PokemonRepository";
+import { globalStyles } from "../../src/theme/styles";
+
+const repo = new PokemonRepository();
+
+export default function BoxesScreen() {
+  const {
+    data: types = [],
+    isLoading,
+    isError,
+  } = useQuery<string[], Error>({
+    queryKey: ["types"],
+    queryFn: () => repo.getTypes(),
+  });
+
+  if (isLoading)
+    return (
+      <View style={globalStyles.containerCenter}>
+        <Text>Carregando tipos…</Text>
+      </View>
+    );
+  if (isError)
+    return (
+      <View style={globalStyles.containerCenter}>
+        <Text>Erro ao carregar tipos.</Text>
+      </View>
+    );
+
+  return (
+    <FlatList
+      data={types}
+      keyExtractor={(item) => item}
+      contentContainerStyle={styles.list}
+      renderItem={({ item }) => (
+        <Link href={`/boxes/${item}`} asChild>
+          <TouchableOpacity style={styles.box}>
+            <Text style={styles.boxText}>{item.toUpperCase()}</Text>
+          </TouchableOpacity>
+        </Link>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { padding: 16 },
+  box: {
+    padding: 12,
+    marginBottom: 8,
+    backgroundColor: "#EEE",
+    borderRadius: 6,
+  },
+  boxText: {
+    textAlign: "center",
+    fontWeight: "600",
+  },
+});

--- a/pokedex/app/favorites.tsx
+++ b/pokedex/app/favorites.tsx
@@ -60,19 +60,25 @@ export default function FavoritesScreen() {
   ).map(([title, data]) => ({ title, data }));
 
   return (
-    <SectionList
-      sections={sections}
-      keyExtractor={(item) => item.id.toString()}
-      renderSectionHeader={({ section: { title } }) => (
-        <View style={styles.header}>
-          <Text style={styles.headerText}>{title.toUpperCase()}</Text>
-        </View>
-      )}
-      renderItem={({ item }) => (
-        <PokemonCard pokemon={item} isFavorite onToggle={() => {}} />
-      )}
-      contentContainerStyle={styles.list}
-    />
+    <View style={{ flex: 1, paddingVertical: 32 }}>
+      {/* Header de favoritos */}
+      <View style={styles.header}>
+        <Text style={styles.headerText}>Pokémons Favoritos</Text>
+      </View>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.id.toString()}
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={styles.header}>
+            <Text style={styles.headerText}>{title.toUpperCase()}</Text>
+          </View>
+        )}
+        renderItem={({ item }) => (
+          <PokemonCard pokemon={item} isFavorite onToggle={() => {}} />
+        )}
+        contentContainerStyle={styles.list}
+      />
+    </View>
   );
 }
 

--- a/pokedex/app/favorites.tsx
+++ b/pokedex/app/favorites.tsx
@@ -2,8 +2,8 @@
 import React from "react";
 import {
   View,
-  FlatList,
   Text,
+  SectionList,
   StyleSheet,
   ActivityIndicator,
 } from "react-native";
@@ -12,18 +12,18 @@ import { useQuery } from "@tanstack/react-query";
 import { FavoriteRepository } from "../src/data/repositories/FavoriteRepository";
 import { globalStyles } from "../src/theme/styles";
 import { PokemonCard } from "../src/components/PokemonCard";
-import type { Pokemon } from "../src/domain/models/Pokemon";
+import type { PokemonWithTypes } from "../src/domain/models/PokemonWithTypes";
 
 const favRepo = new FavoriteRepository();
 
 export default function FavoritesScreen() {
   const {
-    data: favorites = [],
+    data: favs,
     isLoading,
     isError,
-  } = useQuery<Pokemon[], Error>({
-    queryKey: ["favorites"],
-    queryFn: () => favRepo.getFavorites(),
+  } = useQuery<PokemonWithTypes[], Error>({
+    queryKey: ["favoritesWithTypes"],
+    queryFn: () => favRepo.getFavoritesWithTypes(),
   });
 
   if (isLoading) {
@@ -33,7 +33,6 @@ export default function FavoritesScreen() {
       </View>
     );
   }
-
   if (isError) {
     return (
       <View style={globalStyles.containerCenter}>
@@ -41,8 +40,7 @@ export default function FavoritesScreen() {
       </View>
     );
   }
-
-  if (favorites.length === 0) {
+  if (!favs || favs.length === 0) {
     return (
       <View style={globalStyles.containerCenter}>
         <Text>Você não tem favoritos ainda.</Text>
@@ -50,20 +48,45 @@ export default function FavoritesScreen() {
     );
   }
 
+  // agrupa por tipo
+  const sections = Object.entries(
+    favs.reduce((map, p) => {
+      p.types.forEach((type) => {
+        if (!map[type]) map[type] = [];
+        map[type].push(p);
+      });
+      return map;
+    }, {} as Record<string, PokemonWithTypes[]>)
+  ).map(([title, data]) => ({ title, data }));
+
   return (
-    <FlatList
-      data={favorites}
+    <SectionList
+      sections={sections}
       keyExtractor={(item) => item.id.toString()}
-      contentContainerStyle={styles.list}
-      renderItem={({ item }) => (
-        <PokemonCard pokemon={item} isFavorite={true} onToggle={() => {}} />
+      renderSectionHeader={({ section: { title } }) => (
+        <View style={styles.header}>
+          <Text style={styles.headerText}>{title.toUpperCase()}</Text>
+        </View>
       )}
+      renderItem={({ item }) => (
+        <PokemonCard pokemon={item} isFavorite onToggle={() => {}} />
+      )}
+      contentContainerStyle={styles.list}
     />
   );
 }
 
 const styles = StyleSheet.create({
+  header: {
+    backgroundColor: "#EEE",
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+  },
+  headerText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
   list: {
-    paddingVertical: 8,
+    paddingBottom: 16,
   },
 });

--- a/pokedex/app/index.tsx
+++ b/pokedex/app/index.tsx
@@ -67,7 +67,7 @@ export default function PokemonListScreen() {
   const displayData = search.length > 0 && searched ? [searched] : data;
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, paddingVertical: 32 }}>
       <SearchBar value={search} onChangeText={setSearch} />
       <Link href="/favorites" style={styles.link}>
         <Text>Ver Favoritos</Text>

--- a/pokedex/app/index.tsx
+++ b/pokedex/app/index.tsx
@@ -44,7 +44,7 @@ export default function PokemonListScreen() {
 
   const { data, isLoading, isError } = useQuery<Pokemon[]>({
     queryKey: ["pokemons", 0],
-    queryFn: () => repo.getPokemons(0, 20),
+    queryFn: () => repo.getPokemons(0, 151),
   });
 
   if (isLoading) {

--- a/pokedex/src/components/PokemonCard.tsx
+++ b/pokedex/src/components/PokemonCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Text, Image, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import type { Pokemon } from "../domain/models/Pokemon";
+import { Link } from "expo-router";
 
 interface Props {
   pokemon: Pokemon;
@@ -11,17 +12,19 @@ interface Props {
 
 export function PokemonCard({ pokemon, isFavorite, onToggle }: Props) {
   return (
-    <View style={styles.card}>
-      <Image source={{ uri: pokemon.image }} style={styles.image} />
-      <Text style={styles.name}>{pokemon.name}</Text>
-      <TouchableOpacity onPress={() => onToggle(pokemon)} style={styles.icon}>
-        <Ionicons
-          name={isFavorite ? "heart" : "heart-outline"}
-          size={24}
-          color="red"
-        />
-      </TouchableOpacity>
-    </View>
+    <Link href={`/${pokemon.id}`}>
+      <View style={styles.card}>
+        <Image source={{ uri: pokemon.image }} style={styles.image} />
+        <Text style={styles.name}>{pokemon.name}</Text>
+        <TouchableOpacity onPress={() => onToggle(pokemon)} style={styles.icon}>
+          <Ionicons
+            name={isFavorite ? "heart" : "heart-outline"}
+            size={24}
+            color="green"
+          />
+        </TouchableOpacity>
+      </View>
+    </Link>
   );
 }
 
@@ -33,7 +36,11 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderColor: "#DDD",
   },
-  image: { width: 56, height: 56, marginRight: 12 },
+  image: {
+    width: 56,
+    height: 56,
+    marginRight: 12,
+  },
   name: {
     flex: 1,
     fontSize: 18,

--- a/pokedex/src/data/datasources/PokeApiDataSource.ts
+++ b/pokedex/src/data/datasources/PokeApiDataSource.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
-import type { Pokemon } from "../../domain/models/Pokemon";
 import { PokemonDetails } from "../../domain/models/PokemonDetails";
+import { PokemonWithTypes } from "../../domain/models/PokemonWithTypes";
 
 interface PokeApiListResponse {
   count: number;
@@ -29,5 +29,12 @@ export class PokeApiDataSource {
       `https://pokeapi.co/api/v2/pokemon/${nameOrId.toLowerCase()}`
     );
     return data;
+  }
+
+  async fetchTypes(): Promise<PokemonWithTypes[]> {
+    const { data } = await axios.get<{ results: PokemonWithTypes[] }>(
+      `https://pokeapi.co/api/v2/type`
+    );
+    return data.results;
   }
 }

--- a/pokedex/src/data/repositories/FavoriteRepository.ts
+++ b/pokedex/src/data/repositories/FavoriteRepository.ts
@@ -1,5 +1,8 @@
 import { FavoriteDataSource } from "../datasources/FavoriteDataSource";
 import type { Pokemon } from "../../domain/models/Pokemon";
+import { PokeApiDataSource } from "../datasources/PokeApiDataSource";
+import { PokemonRepository } from "./PokemonRepository";
+import { PokemonWithTypes } from "../../domain/models/PokemonWithTypes";
 
 export class FavoriteRepository {
   private ds = new FavoriteDataSource();
@@ -15,5 +18,21 @@ export class FavoriteRepository {
       ? list.filter((p) => p.id !== pokemon.id)
       : [...list, pokemon];
     await this.ds.saveFavorites(updated);
+  }
+
+  async getFavoritesWithTypes(): Promise<PokemonWithTypes[]> {
+    const list = await this.getFavorites();
+    const pokeRepo = new PokemonRepository();
+    return Promise.all(
+      list.map(async (p) => {
+        const details = await pokeRepo.getPokemonById(p.id);
+        return {
+          id: p.id,
+          name: p.name,
+          image: p.image,
+          types: details.types.map((t) => t.type.name),
+        };
+      })
+    );
   }
 }

--- a/pokedex/src/data/repositories/PokemonRepository.ts
+++ b/pokedex/src/data/repositories/PokemonRepository.ts
@@ -5,7 +5,7 @@ import { PokemonDetails } from "../../domain/models/PokemonDetails";
 export class PokemonRepository {
   private api = new PokeApiDataSource();
 
-  async getPokemons(offset = 0, limit = 20): Promise<Pokemon[]> {
+  async getPokemons(offset = 0, limit = 151): Promise<Pokemon[]> {
     const list = await this.api.fetchList(offset, limit);
     return list.results.map((item) => {
       const parts = item.url.split("/").filter(Boolean);

--- a/pokedex/src/data/repositories/PokemonRepository.ts
+++ b/pokedex/src/data/repositories/PokemonRepository.ts
@@ -22,7 +22,6 @@ export class PokemonRepository {
     return this.api.fetchById(id);
   }
 
-  // dentro de class PokemonRepository
   async getPokemonByNameOrId(nameOrId: string): Promise<Pokemon> {
     const details = await this.api.fetchByNameOrId(nameOrId);
     return {
@@ -30,5 +29,10 @@ export class PokemonRepository {
       name: details.name,
       image: details.sprites.front_default,
     };
+  }
+
+  async getTypes(): Promise<string[]> {
+    const types = await this.api.fetchTypes();
+    return types.map((t) => t.name);
   }
 }

--- a/pokedex/src/domain/models/PokemonWithTypes.ts
+++ b/pokedex/src/domain/models/PokemonWithTypes.ts
@@ -1,0 +1,7 @@
+// src/domain/models/PokemonWithTypes.ts
+export interface PokemonWithTypes {
+  id: number;
+  name: string;
+  image: string;
+  types: string[];
+}


### PR DESCRIPTION
1. Novo modelo PokemonWithTypes
2. Método getFavoritesWithTypes no FavoriteRepository, que busca tipos de cada Pokémon
3. Substituição de SectionList em app/favorites.tsx para exibir "caixas" (boxes) por tipo